### PR TITLE
Hotspot v2 fixes

### DIFF
--- a/dhcp/dhcpd.conf
+++ b/dhcp/dhcpd.conf
@@ -1,13 +1,13 @@
 # WLAN Pi DHCP Hotspot Server Config
 # wlan0 DHCP Scope
 subnet 192.168.88.0 netmask 255.255.255.0 {
- interface wlan0;
- range 192.168.88.100 192.168.88.200;
- option routers 192.168.88.1;
- option domain-name-servers 1.1.1.1;
- option domain-name-servers 8.8.8.8;
- default-lease-time 600;
- max-lease-time 7200;
+interface wlan0;
+range 192.168.88.100 192.168.88.200;
+option routers 192.168.88.1;
+option domain-name-servers 1.1.1.1;
+option domain-name-servers 8.8.8.8;
+default-lease-time 86400;
+max-lease-time 86400;
 }
 
 # usb0 DHCP scope
@@ -18,6 +18,6 @@ option domain-name-servers wlanpi.local;
 option domain-name "wlanpi.local";
 option routers 169.254.42.1;
 option broadcast-address 169.254.42.31;
-default-lease-time 600;
-max-lease-time 7200;
+default-lease-time 86400;
+max-lease-time 86400;
 }

--- a/network/interfaces
+++ b/network/interfaces
@@ -1,3 +1,12 @@
+source /etc/network/interfaces.d/*
+
+auto lo
+iface lo inet loopback
+
+# Wired Ethernet
+allow-hotplug eth0
+iface eth0 inet dhcp
+
 # Wireless adapter #1
 allow-hotplug wlan0
 iface wlan0 inet static
@@ -11,8 +20,3 @@ allow-hotplug usb0
 iface usb0 inet static
 address 169.254.42.1
 netmask 255.255.255.224
-
-#WLAN Pi now uses NetworkManager to manage eth0, eth0 section has to be commented out here to prevent 2 IPs from being assigned to eth0 and other conflicts
-# Wired ethernet
-#auto eth0
-#iface eth0 inet dhcp


### PR DESCRIPTION
- eth0 is now configured using /etc/network/interfaces
- extended lease time for clients to 24 hours