### PR TITLE
Fixed incorrect syntax in name servers, use OpenDNS as secondary DNS

### DIFF
--- a/dhcp/dhcpd.conf
+++ b/dhcp/dhcpd.conf
@@ -1,11 +1,11 @@
-# WLAN Pi DHCP Hotspot Server Config
+# WLAN Pi Hotspot Mode DHCP Server Config
+
 # wlan0 DHCP Scope
 subnet 192.168.88.0 netmask 255.255.255.0 {
 interface wlan0;
 range 192.168.88.100 192.168.88.200;
 option routers 192.168.88.1;
-option domain-name-servers 1.1.1.1;
-option domain-name-servers 8.8.8.8;
+option domain-name-servers 8.8.8.8, 208.67.222.222;
 default-lease-time 86400;
 max-lease-time 86400;
 }

--- a/network/interfaces
+++ b/network/interfaces
@@ -12,7 +12,7 @@ allow-hotplug wlan0
 iface wlan0 inet static
 address 192.168.88.1
 netmask 255.255.255.0
-dns-nameservers 8.8.8.8 8.8.4.4
+dns-nameservers 8.8.8.8 208.67.222.222
 hostapd /etc/hostapd.conf
 
 # USB interface


### PR DESCRIPTION
Use OpenDNS secondary DNS in case Google is blocked on the network. Happy to chat about any other suggestions.